### PR TITLE
Remove bottle :uneeded of sourcery

### DIFF
--- a/sourcery.rb
+++ b/sourcery.rb
@@ -4,8 +4,6 @@ class Sourcery < Formula
   url "https://github.com/krzysztofzablocki/Sourcery/releases/download/0.13.1/Sourcery-0.13.1.zip"
   sha256 "86f85f4fa3de3cca5c3ca5886f8d0234d0509ebfa8dd4ec6a3d9d84f0839d2cc"
   
-  bottle :unneeded
-
   def install
     bin.install "bin/sourcery"
     libexec.install "bin/Sourcery.app"


### PR DESCRIPTION
`bottle :unneeded` was marked as `disabled`

<img width="933" alt="image" src="https://user-images.githubusercontent.com/207553/155993678-60e96963-f8d1-42a3-965c-4deb80a1e60f.png">
